### PR TITLE
Added batch file to initialise terminal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
     "files.associations": {
         "cstdio": "c",
         "tc.h": "c",
-        "io.h": "c"
+        "io.h": "c",
+        "type_content.h": "c",
+        "user_manage.h": "c"
     }
 }

--- a/init_terminal.bat
+++ b/init_terminal.bat
@@ -1,0 +1,3 @@
+@ECHO off
+cmd /k "reg add HKEY_CURRENT_USER\Console /v VirtualTerminalLevel /t REG_DWORD /d 0x00000001 /f"
+pause


### PR DESCRIPTION
Created batch file `init_terminal.bat` to initialize the terminal to support ANSI characters. 
This is a necessary step in solving issue #34 